### PR TITLE
for文で特定の変数名が文字数のときフォーマットに失敗していたのを修正

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -414,7 +414,7 @@ type Unary struct {
 	Unary       string   `( @("!"|"-")`
 	FeedBackOp  string   `| @"&")?`
 	Primary     *Primary `@@`
-	OperCalcOne string   `@((?! Space|TabSpace|LF|BlankLine) ("+" "+"|"--"))?`
+	OperCalcOne string   `@((?! Space|TabSpace|LF|BlankLine) (OperAsignUnary | "--"))?`
 }
 
 func (u Unary) String() string {

--- a/ast/lexer.go
+++ b/ast/lexer.go
@@ -44,7 +44,7 @@ var (
 			{Name: "HearDocumentSingle", Pattern: `(?sU)<<'.*'>>`, Action: nil},
 			{Name: "HearDocumentDouble", Pattern: `(?sU)<<".*">>`, Action: nil},
 			{Name: `OperAsign`, Pattern: `(=|:=|\+=|-=|\*=|/=|%=|\+:=|-:=|\*:=|/:=|%:=|,=)`, Action: nil},
-			{Name: `OperAsignUnary`, Pattern: `[^ 	](--|\+\+)`, Action: nil},
+			{Name: `OperAsignUnary`, Pattern: `(--|\+\+)`, Action: nil},
 			{Name: `OperUnary`, Pattern: `(!|-|&)`, Action: nil},
 			{Name: `OperCalc`, Pattern: `(-|\+|/|\*|%)`, Action: nil},
 			{Name: `OperComp`, Pattern: `(==|!=|>=|<=|>|<|_in_|!_in_)`, Action: nil},

--- a/testdata/yaya_bootend.dic
+++ b/testdata/yaya_bootend.dic
@@ -91,3 +91,10 @@ Bye
   }
   'h1111207bye\_w[1200]'
 }
+
+OnTest
+{
+  result=0
+  for i=1; i<11; i++ {result+=i}
+  '\1\s[10]\0\s[0]1から10まで全部足すと'+result+'です。\e'
+}


### PR DESCRIPTION
close #1